### PR TITLE
Embed default OAuth client ID

### DIFF
--- a/OAuth_Manager.py
+++ b/OAuth_Manager.py
@@ -5,7 +5,9 @@ import requests
 
 from Token_Manager import add_token
 
-CLIENT_ID = os.getenv('GITHUB_OAUTH_CLIENT_ID')
+# Default GitHub OAuth client ID used if no environment variable is provided
+DEFAULT_CLIENT_ID = 'Iv23liC8cOnETRR9IEV4'
+CLIENT_ID = os.getenv('GITHUB_OAUTH_CLIENT_ID', DEFAULT_CLIENT_ID)
 CLIENT_SECRET = os.getenv('GITHUB_OAUTH_CLIENT_SECRET')
 SCOPE = os.getenv('GITHUB_OAUTH_SCOPE', 'repo')
 
@@ -14,8 +16,6 @@ TOKEN_URL = 'https://github.com/login/oauth/access_token'
 
 
 def initiate_device_flow():
-    if not CLIENT_ID:
-        raise RuntimeError('GITHUB_OAUTH_CLIENT_ID environment variable not set.')
     data = {'client_id': CLIENT_ID, 'scope': SCOPE}
     headers = {'Accept': 'application/json'}
     response = requests.post(DEVICE_URL, data=data, headers=headers)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 GitSleuth searches GitHub repositories for sensitive data. It provides both a command-line interface and a PyQt5 GUI.
 
 ## Features
-- Predefined and custom search queries
-- Token rotation to handle API rate limits
-- OAuth device flow authentication
+- Predefined and custom search queries with extensive templates from
+  [ADVANCED_QUERIES.md](ADVANCED_QUERIES.md) and
+  [SEARCH_QUERIES.md](SEARCH_QUERIES.md)
+- OAuth device flow authentication with token rotation and secure token
+  storage to handle API rate limits
 - Export results to Excel or CSV
-- Secure token storage
-- Extensive templates in [ADVANCED_QUERIES.md](ADVANCED_QUERIES.md) and [SEARCH_QUERIES.md](SEARCH_QUERIES.md)
-- Sleek dark theme (GUI) without the old rule editor pane
+- Sleek dark theme for the GUI
 
 ## Installation
 ### Prerequisites
@@ -43,6 +43,9 @@ python GitSleuth.py
 
 ## Configuration
 Edit `config.json` to adjust log level and ignored filenames.
+The OAuth flow uses a default GitHub client ID of `Iv23liC8cOnETRR9IEV4`.
+Set the `GITHUB_OAUTH_CLIENT_ID` environment variable to override it and
+`GITHUB_OAUTH_CLIENT_SECRET` for private applications.
 
 ## Contributing
 Contributions are welcome. Please follow standard open-source practices.


### PR DESCRIPTION
## Summary
- add a default GitHub OAuth client ID so the app works without environment variables
- document the default ID and how to override it in the README

## Testing
- `python -m py_compile *.py`
- `git status --short`
