### PR TITLE
Fix OAuth manager indentation

### DIFF
--- a/OAuth_Manager.py
+++ b/OAuth_Manager.py
@@ -15,7 +15,9 @@ TOKEN_URL = 'https://github.com/login/oauth/access_token'
 
 def initiate_device_flow():
     if not CLIENT_ID:
-        raise RuntimeError('GITHUB_OAUTH_CLIENT_ID environment variable not set.')
+        raise RuntimeError(
+            "GITHUB_OAUTH_CLIENT_ID environment variable not set." 
+        )
     data = {'client_id': CLIENT_ID, 'scope': SCOPE}
     headers = {'Accept': 'application/json'}
     response = requests.post(DEVICE_URL, data=data, headers=headers)
@@ -24,11 +26,12 @@ def initiate_device_flow():
 
 
 def poll_for_token(device_code, interval):
+    """Poll GitHub for the OAuth token using the provided device code."""
     data = {
-        'client_id': CLIENT_ID,
-        'device_code': device_code,
-        'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
-        'client_secret': CLIENT_SECRET,
+        "client_id": CLIENT_ID,
+        "device_code": device_code,
+        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        "client_secret": CLIENT_SECRET,
     }
     headers = {'Accept': 'application/json'}
     while True:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 GitSleuth searches GitHub repositories for sensitive data. It provides both a command-line interface and a PyQt5 GUI.
 
 ## Features
-- Predefined and custom search queries
-- Token rotation to handle API rate limits
-- OAuth device flow authentication
+- Predefined and custom search queries with extensive templates from
+  [ADVANCED_QUERIES.md](ADVANCED_QUERIES.md) and
+  [SEARCH_QUERIES.md](SEARCH_QUERIES.md)
+- OAuth device flow authentication with token rotation and secure token
+  storage to handle API rate limits
 - Export results to Excel or CSV
-- Secure token storage
-- Extensive templates in [ADVANCED_QUERIES.md](ADVANCED_QUERIES.md) and [SEARCH_QUERIES.md](SEARCH_QUERIES.md)
-- Sleek dark theme (GUI) without the old rule editor pane
+- Sleek dark theme for the GUI
 
 ## Installation
 ### Prerequisites


### PR DESCRIPTION
## Summary
- handle OAuth client ID error message cleanly
- document poll_for_token and ensure consistent indentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
