### PR TITLE
Fix README sentence and add time import

### DIFF
--- a/GitSleuth_API.py
+++ b/GitSleuth_API.py
@@ -3,6 +3,7 @@ import requests
 import base64
 import logging
 import os
+import time
 from OAuth_Manager import oauth_login
 from Token_Manager import load_tokens
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 GitSleuth searches GitHub repositories for sensitive data. It provides both a command-line interface and a PyQt5 GUI.
 
 ## Features
-- Predefined and custom search queries
-- Token rotation to handle API rate limits
-- OAuth device flow authentication
+- Predefined and custom search queries with extensive templates from
+  [ADVANCED_QUERIES.md](ADVANCED_QUERIES.md) and
+  [SEARCH_QUERIES.md](SEARCH_QUERIES.md)
+- OAuth device flow authentication with token rotation and secure token
+  storage to handle API rate limits
 - Export results to Excel or CSV
-- Secure token storage
-- Extensive templates in [ADVANCED_QUERIES.md](ADVANCED_QUERIES.md) and [SEARCH_QUERIES.md](SEARCH_QUERIES.md)
-- Sleek dark theme (GUI) without the old rule editor pane
+- Sleek dark theme for the GUI
 
 ## Installation
 ### Prerequisites
@@ -34,7 +34,7 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
 ```bash
 python GitSleuth_GUI.py
 ```
-The GUI now defaults to a dark theme for improved readability and no longer
+The GUI now defaults to a dark theme for improved readability.
 
 ### CLI
 ```bash


### PR DESCRIPTION
## Summary
- fix truncated sentence about GUI theme in README
- import `time` in `GitSleuth_API.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
