### PR TITLE
Add setup script for offline dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
    cd GitSleuth
    ```
 2. Install dependencies
+   Run the setup script to ensure all requirements are installed while network
+   access is available.
    ```bash
-   pip install -r requirements.txt
+   ./setup.sh
    ```
 
 ## Usage

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Setup script to install dependencies before network access is disabled.
+set -e
+
+# Change to the directory of the script
+cd "$(dirname "$0")"
+
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper script for installing project requirements
- document the script usage in the installation steps

## Testing
- `python -m py_compile *.py` *(fails: SyntaxError in OAuth_Manager.py)*