### PR TITLE
Fix double OAuth prompt

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -245,27 +245,17 @@ class GitSleuthGUI(QMainWindow):
         self.log_output.clear()
 
     def start_oauth(self):
-
-        """Trigger OAuth device flow."""
-        result = oauth_login()
-        if result:
-            token, username = result
-
         """Trigger OAuth device flow and update UI."""
 
         token, username = oauth_login()
         if token:
-
             os.environ["GITHUB_OAUTH_TOKEN"] = token
-            if hasattr(self, 'oauth_btn') and username:
+            if hasattr(self, "oauth_btn") and username:
                 self.oauth_btn.setText(f"Logged in as: {username}")
             self.status_bar.showMessage("OAuth login successful")
 
             if username:
                 self.oauth_button.setText(f"Logged in as: {username}")
-
-            if hasattr(self, "oauth_btn"):
-                self.oauth_btn.setText(f"Logged in as: {username}")
 
         else:
             self.status_bar.showMessage("OAuth login failed")


### PR DESCRIPTION
## Summary
- remove duplicate call to `oauth_login` in `GitSleuth_GUI.start_oauth`

## Testing
- `python -m py_compile $(git ls-files '*.py')`