### PR TITLE
Improve GUI handling of rate limit pauses

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -379,6 +379,15 @@ class GitSleuthGUI(QMainWindow):
         else:
             self.export_button.setEnabled(False)
 
+    def wait_with_events(self, wait_time):
+        """Sleep in small intervals while processing GUI events."""
+        end_time = time.time() + wait_time
+        while time.time() < end_time:
+            if not self.search_active:
+                break
+            QApplication.processEvents()
+            time.sleep(0.1)
+
     def process_query(self, query, max_retries, config, search_term):
         retry_count = 0
         while retry_count < max_retries:
@@ -390,7 +399,7 @@ class GitSleuthGUI(QMainWindow):
                     if switch_token(config):
                         headers = get_headers()
                     else:
-                        time.sleep(wait_time or 60)
+                        self.wait_with_events(wait_time or 60)
                 search_results = GitSleuth_API.search_github_code(query, headers)
                 self.handle_search_results(search_results, query, headers, search_term)
                 break
@@ -401,7 +410,7 @@ class GitSleuthGUI(QMainWindow):
                 else:
                     wait_time = getattr(e, 'wait_time', 60)
                     logging.info(f"Waiting {int(wait_time)} seconds for rate limit reset.")
-                    time.sleep(wait_time)
+                    self.wait_with_events(wait_time)
 
                 logging.warning(f"Rate limit reached: {str(e)}")
                 


### PR DESCRIPTION
## Summary
- add `wait_with_events` helper to avoid UI blocking
- use the new helper when waiting for rate limit resets

## Testing
- `python -m py_compile GitSleuth_GUI.py GitSleuth_API.py GitSleuth.py OAuth_Manager.py Token_Manager.py GitSleuth_Groups.py`
