### PR TITLE
Ensure start and stop buttons update with search state

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -281,6 +281,7 @@ class GitSleuthGUI(QMainWindow):
         self.progress_bar.setValue(0)
         self.status_bar.showMessage("Search stopped.")
         self.check_enable_export()
+        QApplication.processEvents()  # Ensure UI updates after stopping
     def export_results_to_csv(self):
         """
         Exports the search results displayed in the table to a CSV file.
@@ -333,12 +334,13 @@ class GitSleuthGUI(QMainWindow):
 
         self.search_active = True
         self.statusBar().showMessage(f"Searching in {selected_group} for domain: {domain}")
-        self.stop_button.setEnabled(True)  # Uncomment if stop functionality is desired
+        self.stop_button.setEnabled(True)  # Allow user to stop the search
         self.search_button.setEnabled(False)
         self.export_button.setEnabled(False)  # Explicitly disable the export button
         self.progress_bar.setValue(0)
+        QApplication.processEvents()  # Refresh UI state before starting search
         self.perform_search(domain, selected_group)
- 
+
     def perform_search(self, domain, selected_group):
         config = load_config()
         search_groups = create_search_queries(domain)
@@ -363,6 +365,15 @@ class GitSleuthGUI(QMainWindow):
                 self.completed_queries += 1
                 self.progress_bar.setValue(self.completed_queries)
                 QApplication.processEvents()
+
+        # Search finished normally
+        if self.search_active:
+            self.search_active = False
+            self.search_button.setEnabled(True)
+            self.stop_button.setEnabled(False)
+            self.check_enable_export()
+            self.status_bar.showMessage("Search completed.")
+            QApplication.processEvents()  # Reflect updated button states
 
 
     def check_enable_export(self):
@@ -450,7 +461,6 @@ class GitSleuthGUI(QMainWindow):
         if self.results_table.rowCount() > 0:
             self.export_button.setEnabled(True)
             self.clear_results_button.setEnabled(True)  # Enable the clear results button
-            self.stop_button.setEnabled(False)
             self.status_bar.showMessage("Results found.")
             logging.info("Results found.")
 


### PR DESCRIPTION
## Summary
- disable the Stop button only when not searching
- re-enable the Search button after searches finish
- refresh button states using QApplication.processEvents

## Testing
- `bash setup.sh` *(fails: could not fetch dependencies)*
- `python -m py_compile GitSleuth_GUI.py`
