### PR TITLE
Restrict default OAuth scope

### DIFF
--- a/OAuth_Manager.py
+++ b/OAuth_Manager.py
@@ -18,7 +18,8 @@ from Token_Manager import add_token
 DEFAULT_CLIENT_ID = "Iv23liC8cOnETRR9IEV4"
 CLIENT_ID = os.getenv('GITHUB_OAUTH_CLIENT_ID', DEFAULT_CLIENT_ID)
 CLIENT_SECRET = os.getenv('GITHUB_OAUTH_CLIENT_SECRET')
-SCOPE = os.getenv('GITHUB_OAUTH_SCOPE', 'repo')
+# Request read-only repository access by default
+SCOPE = os.getenv('GITHUB_OAUTH_SCOPE', 'public_repo')
 
 DEVICE_URL = "https://github.com/login/device/code"
 TOKEN_URL = "https://github.com/login/oauth/access_token"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Edit `config.json` to adjust log level and ignored filenames. The
 application ships with a default GitHub OAuth client ID so it works out of
 the box. Set `GITHUB_OAUTH_CLIENT_ID` to override it and define
 `GITHUB_OAUTH_CLIENT_SECRET` if your OAuth app requires a secret.
+By default the application requests the `public_repo` OAuth scope for
+read-only access. Override this by setting `GITHUB_OAUTH_SCOPE` if you
+require additional permissions.
 
 
 ## Contributing


### PR DESCRIPTION
## Summary
- request `public_repo` scope by default in `OAuth_Manager`
- document new default OAuth scope in README

## Testing
- `python -m py_compile OAuth_Manager.py`
- `python -m py_compile *.py`
- `python -m unittest discover`
