### PR TITLE
Switch to keyword search field

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -183,12 +183,11 @@ class GitSleuthGUI(QMainWindow):
         Args:
             layout (QHBoxLayout): The layout to add the search input area to.
         """
-        # Add a QComboBox for domain selection
-        self.domain_dropdown = QComboBox(self)
-        layout.addWidget(QLabel("Domain:"))
-        layout.addWidget(self.domain_dropdown)
-        # Populate the dropdown with sample domains
-        self.domain_dropdown.addItems(["temp.com", "example.com"])
+        # Add a QLineEdit for keyword entry
+        self.keyword_input = QLineEdit(self)
+        layout.addWidget(QLabel("Keywords:"))
+        layout.addWidget(self.keyword_input)
+        self.keyword_input.setPlaceholderText("Enter keywords or domain")
         self.search_group_dropdown = QComboBox(self)
         layout.addWidget(self.search_group_dropdown)
         self.search_group_dropdown.addItems(["Authentication and Credentials", "API Keys and Tokens",
@@ -321,10 +320,10 @@ class GitSleuthGUI(QMainWindow):
         """
         Handles the event when the search button is clicked.
         """
-        # Use the current text of the domain dropdown
-        domain = self.domain_dropdown.currentText()
-        if not domain:
-            self.statusBar().showMessage("Domain is required for searching.")
+        # Use the entered keywords for filtering
+        keywords = self.keyword_input.text().strip()
+        if not keywords:
+            self.statusBar().showMessage("Keywords are required for searching.")
             return
 
         selected_group = self.search_group_dropdown.currentText()
@@ -333,17 +332,19 @@ class GitSleuthGUI(QMainWindow):
         self.results_table.update()  # Force update of the results table
 
         self.search_active = True
-        self.statusBar().showMessage(f"Searching in {selected_group} for domain: {domain}")
+        self.statusBar().showMessage(
+            f"Searching in {selected_group} for keywords: {keywords}"
+        )
         self.stop_button.setEnabled(True)  # Allow user to stop the search
         self.search_button.setEnabled(False)
         self.export_button.setEnabled(False)  # Explicitly disable the export button
         self.progress_bar.setValue(0)
         QApplication.processEvents()  # Refresh UI state before starting search
-        self.perform_search(domain, selected_group)
+        self.perform_search(keywords, selected_group)
 
-    def perform_search(self, domain, selected_group):
+    def perform_search(self, keywords, selected_group):
         config = load_config()
-        search_groups = create_search_queries(domain)
+        search_groups = create_search_queries(keywords)
         max_retries = 3
 
         if selected_group == "Search All":

--- a/GitSleuth_Groups.py
+++ b/GitSleuth_Groups.py
@@ -1,18 +1,20 @@
 #GitSleuth_Groups.py
-def create_search_queries(domain):
+def create_search_queries(keywords):
     """
     Creates a dictionary of search queries for different categories,
-    incorporating the given domain and applying strategies to exclude common placeholders.
+    incorporating the provided keywords and applying strategies to exclude
+    common placeholders.
 
     Parameters:
-    - domain (str): The domain to be included in the search queries.
+    - keywords (str): Keywords or domain terms to include in the search
+      queries.
 
     Returns:
     - dict: A dictionary where each key is a category, and the value is a list of search queries.
     """
     placeholders = "NOT example NOT dummy NOT test NOT sample NOT placeholder"
 
-    domain_filter = f'"{domain}"' if domain else ""
+    domain_filter = f'"{keywords}"' if keywords else ""
     return {
         "Authentication and Credentials": [
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
   storage to handle API rate limits
 - Export results to Excel or CSV
 - Sleek dark theme for the GUI
+- Keyword filter field in the GUI for quickly narrowing searches
 
 ## Installation
 ### Prerequisites
@@ -37,6 +38,7 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
 ```bash
 python GitSleuth_GUI.py
 ```
+Use the **Keywords** field to limit searches to specific domains or terms.
 
 
 ### CLI


### PR DESCRIPTION
## Summary
- replace domain dropdown with keyword text field in the GUI
- document new keyword field in README
- adjust search query helper to accept keywords

## Testing
- `python -m py_compile GitSleuth_GUI.py GitSleuth_Groups.py`
- `pytest -q` *(fails: command not found)*