### PR TITLE
Add persistent OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
 - Sleek dark theme for the GUI
 - Keyword filter field in the GUI for quickly narrowing searches
 
+- Optional session keep-alive after closing the GUI
+- Automatic restoration of your OAuth login on launch
+
 - Results table now shows a short description for each rule
 
 

--- a/config.json
+++ b/config.json
@@ -4,5 +4,7 @@
         "example.txt",
         "test.md",
         "sample.config"
-    ]
+    ],
+    "SESSION_KEEP_ALIVE_MINUTES": 0,
+    "SAVED_USERNAME": ""
 }


### PR DESCRIPTION
## Summary
- remember last GitHub username in `config.json`
- restore saved OAuth token on launch and update login button
- persist username from both login flows
- document automatic login restoration in README

## Testing
- `python -m py_compile GitSleuth_GUI.py`
