### PR TITLE
Fix search input layout in GUI

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -200,60 +200,13 @@ class GitSleuthGUI(QMainWindow):
     def setupSearchInputArea(self, layout):
         """Build the search input widgets and action buttons."""
 
-        self.keyword_input = QLineEdit(self)
-
-
-        layout.addWidget(QLabel("Keywords:"))
-        self.keyword_input = QLineEdit(self)
-
-        self.keyword_input.setPlaceholderText("Enter keywords or domain")
-        layout.addWidget(self.keyword_input)
-
-        self.search_group_dropdown = QComboBox(self)
-        self.search_group_dropdown.addItems([
-            "Authentication and Credentials",
-            "API Keys and Tokens",
-            "Database and Server Configurations",
-            "Security and Code Vulnerabilities",
-            "Historical Data and Leakage",
-            "Custom and Regex-Based Searches",
-        ])
-
-        self.keyword_input.setPlaceholderText("Enter keywords or domain")
-        layout.addWidget(self.keyword_input)
-
-        self.search_group_dropdown = QComboBox(self)
-        self.search_group_dropdown.addItems([
-            "Authentication and Credentials",
-            "API Keys and Tokens",
-            "Database and Server Configurations",
-            "Security and Code Vulnerabilities",
-            "Historical Data and Leakage",
-            "Custom and Regex-Based Searches",
-        ])
-
         form_layout = QHBoxLayout()
-
+        form_layout.addWidget(QLabel("Keywords:"))
         self.keyword_input = QLineEdit(self)
         self.keyword_input.setPlaceholderText("Enter keywords or domain")
-
-
-        self.search_group_dropdown = QComboBox(self)
-        self.search_group_dropdown.addItems([
-            "Authentication and Credentials",
-            "API Keys and Tokens",
-            "Database and Server Configurations",
-            "Security and Code Vulnerabilities",
-            "Historical Data and Leakage",
-            "Custom and Regex-Based Searches",
-        ])
-
         form_layout.addWidget(self.keyword_input)
 
         self.search_group_dropdown = QComboBox(self)
-
-get(self.search_group_dropdown)
-
         self.search_group_dropdown.addItems([
             "Authentication and Credentials",
             "API Keys and Tokens",
@@ -262,11 +215,8 @@ get(self.search_group_dropdown)
             "Historical Data and Leakage",
             "Custom and Regex-Based Searches",
         ])
-
         form_layout.addWidget(self.search_group_dropdown)
         layout.addLayout(form_layout)
-
-
 
         button_layout = QHBoxLayout()
         self.search_button = QPushButton("Search", self)
@@ -285,15 +235,16 @@ get(self.search_group_dropdown)
         self.oauth_button.clicked.connect(self.start_oauth)
         button_layout.addWidget(self.oauth_button)
 
-
         self.logout_button = QPushButton("Logout", self)
         self.logout_button.setFixedWidth(100)
         self.logout_button.clicked.connect(self.logout_user)
         button_layout.addWidget(self.logout_button)
+
         self.quit_button = QPushButton("Quit", self)
         self.quit_button.setFixedWidth(90)
         self.quit_button.clicked.connect(self.close)
         button_layout.addWidget(self.quit_button)
+
         layout.addLayout(button_layout)
 
 


### PR DESCRIPTION
## Summary
- remove duplicated widgets in `setupSearchInputArea`
- restore the original layout for search inputs and action buttons

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`
