### PR TITLE
Fix undefined button_layout in GitSleuth GUI

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -211,6 +211,11 @@ class GitSleuthGUI(QMainWindow):
         self.keyword_input.setMinimumWidth(250)
         form_layout.addWidget(self.keyword_input)
 
+        # Add the form layout to the provided layout
+        layout.addLayout(form_layout)
+
+        button_layout = QHBoxLayout()
+
 
         self.search_group_dropdown = QComboBox(self)
         layout.addWidget(self.search_group_dropdown)


### PR DESCRIPTION
## Summary
- initialize `button_layout` in `setupSearchInputArea`
- add missing form layout to the main layout before creating action buttons

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`
