### PR TITLE
Add configurable placeholder filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - Introduced session keep-alive feature
 - Bumped `requests` to 2.32.2
 - Multiple README updates and improvements
+- Added configuration option to toggle placeholder filtering in queries
 
 ## 2025-05-21
 - Added comprehensive secret detection queries

--- a/GitSleuth.py
+++ b/GitSleuth.py
@@ -144,7 +144,8 @@ def perform_search(domain, selected_group, config, max_retries=3, search_timeout
     start_time = time.time()  # Start time of the search
     last_result_time = start_time  # Last result found time
 
-    search_groups = create_search_queries(domain)
+    filter_placeholders = config.get("FILTER_PLACEHOLDERS", True)
+    search_groups = create_search_queries(domain, filter_placeholders=filter_placeholders)
 
     for group in (search_groups if selected_group == "Search All" else [selected_group]):
         for query in search_groups.get(group, []):
@@ -541,8 +542,9 @@ def perform_grouped_searches(domain):
     Parameters:
     - domain (str): The domain to be used in the search queries.
     """
-    updated_search_groups = create_search_queries(domain)
     config = load_config()
+    filter_placeholders = config.get("FILTER_PLACEHOLDERS", True)
+    updated_search_groups = create_search_queries(domain, filter_placeholders=filter_placeholders)
     ignored_filenames = config.get('IGNORED_FILENAMES', [])
     all_data = []  # Initialize an empty list to store all the search results
 

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -34,7 +34,11 @@ from PyQt5.QtCore import QUrl, Qt, QTimer
 from PyQt5.QtGui import QDesktopServices, QPalette, QColor
 
 import GitSleuth_API
-from GitSleuth_Groups import create_search_queries, get_query_description
+from GitSleuth_Groups import (
+    create_search_queries,
+    get_query_description,
+    PLACEHOLDERS,
+)
 from GitSleuth import extract_snippets, switch_token
 from GitSleuth_API import RateLimitException, get_headers, check_rate_limit
 from OAuth_Manager import oauth_login
@@ -459,7 +463,10 @@ class GitSleuthGUI(QMainWindow):
 
     def perform_search(self, keywords, selected_group):
         config = load_config()
-        search_groups = create_search_queries(keywords)
+        filter_placeholders = config.get("FILTER_PLACEHOLDERS", True)
+        search_groups = create_search_queries(
+            keywords, filter_placeholders=filter_placeholders
+        )
         max_retries = 3
 
         if selected_group == "Search All":
@@ -599,7 +606,7 @@ class GitSleuthGUI(QMainWindow):
             self.results_table.insertRow(row_position)
 
             # Filter out unwanted terms from the search term
-            filtered_search_term = search_term.replace("ge.com NOT example NOT dummy NOT test NOT sample NOT placeholder", "").strip()
+            filtered_search_term = search_term.replace(PLACEHOLDERS, "").strip()
 
             # Search term column
             self.results_table.setItem(row_position, 0, QTableWidgetItem(filtered_search_term))

--- a/GitSleuth_Groups.py
+++ b/GitSleuth_Groups.py
@@ -34,13 +34,15 @@ def get_query_description(query, domain=""):
 
 
 
-def create_search_queries(keywords):
+def create_search_queries(keywords, filter_placeholders=True):
     """Return categorized GitHub search queries.
 
     Parameters
     ----------
     keywords : str
         Extra keywords or a domain to narrow the search.
+    filter_placeholders : bool
+        If True, exclude common placeholder terms from queries.
 
     Returns
     -------
@@ -48,7 +50,7 @@ def create_search_queries(keywords):
         Mapping of group name to list of query strings.
     """
 
-    placeholders = "NOT example NOT dummy NOT test NOT sample NOT placeholder"
+    placeholders = PLACEHOLDERS if filter_placeholders else ""
     domain_filter = f'"{keywords}"' if keywords else ""
 
     return {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ When starting OAuth authentication, your default browser will automatically open
 to the GitHub device flow page so you can enter the provided code.
 
 ## Configuration
-Edit `config.json` to adjust log level and ignored filenames. The
+Edit `config.json` to adjust log level, ignored filenames, and whether
+placeholder terms are filtered from queries. The
 application ships with a default GitHub OAuth client ID so it works out of
 the box. Set `GITHUB_OAUTH_CLIENT_ID` to override it and define
 `GITHUB_OAUTH_CLIENT_SECRET` if your OAuth app requires a secret.

--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
         "sample.config"
     ],
     "SESSION_KEEP_ALIVE_MINUTES": 0,
-    "SAVED_USERNAME": ""
+    "SAVED_USERNAME": "",
+    "FILTER_PLACEHOLDERS": true
 
 }


### PR DESCRIPTION
## Summary
- add `FILTER_PLACEHOLDERS` option in `config.json`
- make placeholder filtering optional when building queries
- use the flag in CLI and GUI search logic
- show descriptions cleaned from placeholder strings
- document the new option in README and changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`