### PR TITLE
Add configurable placeholder filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project are documented in this file.
 - Introduced session keep-alive feature
 - Bumped `requests` to 2.32.2
 - Multiple README updates and improvements
+- Added configuration option to toggle placeholder filtering in queries
+- Results referencing environment variables are now ignored when
+  placeholder filtering is enabled
 
 ## 2025-05-21
 - Added comprehensive secret detection queries

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ When starting OAuth authentication, your default browser will automatically open
 to the GitHub device flow page so you can enter the provided code.
 
 ## Configuration
-Edit `config.json` to adjust log level and ignored filenames. The
+Edit `config.json` to adjust log level, ignored filenames, and whether
+placeholder terms or environment variable references are filtered from
+queries and results. The
 application ships with a default GitHub OAuth client ID so it works out of
 the box. Set `GITHUB_OAUTH_CLIENT_ID` to override it and define
 `GITHUB_OAUTH_CLIENT_SECRET` if your OAuth app requires a secret.

--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
         "sample.config"
     ],
     "SESSION_KEEP_ALIVE_MINUTES": 0,
-    "SAVED_USERNAME": ""
+    "SAVED_USERNAME": "",
+    "FILTER_PLACEHOLDERS": true
 
 }


### PR DESCRIPTION
## Summary
- add `FILTER_PLACEHOLDERS` option in `config.json`
- make placeholder filtering optional when building queries
- use the flag in CLI and GUI search logic
- show descriptions cleaned from placeholder strings
- ignore environment variable placeholders in snippets
- document the new option in README and changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`