### PR TITLE
Add modern API token queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,7 @@
-__pycache__/GitSleuth_API.cpython-312.pyc
-__pycache__/GitSleuth_Groups.cpython-312.pyc
-__pycache__/GitSleuth.cpython-312.pyc
-__pycache__/GitSleuth_API.cpython-311.pyc
-__pycache__/GitSleuth_Groups.cpython-311.pyc
-__pycache__/GitSleuth.cpython-311.pyc
+__pycache__/
+*.pyc
 token_key.key
 .DS_Store
-GS-Previous/__pycache__/GitSleuth_API.cpython-311.pyc
-GS-Previous/__pycache__/GitSleuth_Groups.cpython-311.pyc
-GS-Previous/__pycache__/GitSleuth.cpython-311.pyc
+GS-Previous/__pycache__/
 tokens.json
 GS-Previous.zip

--- a/ADVANCED_QUERIES.md
+++ b/ADVANCED_QUERIES.md
@@ -72,6 +72,11 @@ Search queries to detect exposed credentials for major cloud providers like Amaz
 | `NPM_TOKEN` | **npm** registry tokens. |
 | `SLACK_API_TOKEN` | Slack API tokens or legacy Slack bot tokens. |
 | `API_KEY` | Generic usage of "API_KEY" in code. |
+| `VERCEL_API_TOKEN` | **Vercel** platform API tokens. |
+| `HUGGINGFACEHUB_API_TOKEN` | **Hugging Face** API tokens. |
+| `SUPABASE_SERVICE_ROLE_KEY` | **Supabase** service role keys. |
+| `SENTRY_DSN` | **Sentry** DSN strings containing secrets. |
+| `ROLLBAR_ACCESS_TOKEN` | **Rollbar** access tokens. |
 
 ## OAuth Client IDs and Secrets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 - Placeholder for future changes
 
+## 2025-05-23
+- Added search patterns for modern API tokens including Vercel, Hugging Face,
+  Supabase, Sentry, and Rollbar.
+- Updated `ADVANCED_QUERIES.md`, `SEARCH_QUERIES.md`, and
+  `GitSleuth_Groups.py` to include these new queries.
+
 ## 2025-05-22
 - Created this CHANGELOG in response to a chat request
 - Added persistent OAuth login across restarts

--- a/GitSleuth.py
+++ b/GitSleuth.py
@@ -449,10 +449,6 @@ def view_github_token():
 
 
 def switch_token(config=None):
-    """Switch to the next available token."""
-    return token_switch(config)
-
-def switch_token(config=None):
     """Rotate the current OAuth token using saved tokens."""
     return rotate_token(config)
 

--- a/GitSleuth_API.py
+++ b/GitSleuth_API.py
@@ -73,34 +73,26 @@ def fetch_paginated_data(url, headers, max_items=100):
 _OAUTH_TOKEN = None
 
 def get_headers():
-
-    """Return headers for GitHub API requests using an OAuth token."""
+    """Generate headers for GitHub API requests."""
     global _OAUTH_TOKEN
     if not _OAUTH_TOKEN:
         _OAUTH_TOKEN = os.environ.get("GITHUB_OAUTH_TOKEN")
         if not _OAUTH_TOKEN:
-            _OAUTH_TOKEN = oauth_login()
+            tokens = load_tokens()
+            if tokens:
+                _OAUTH_TOKEN = list(tokens.values())[0]
+            else:
+                _OAUTH_TOKEN = oauth_login()
             if not _OAUTH_TOKEN:
+                logging.error("No GitHub tokens available.")
                 return {}
             os.environ["GITHUB_OAUTH_TOKEN"] = _OAUTH_TOKEN
     logging.debug("Using OAuth token")
-    return {"Authorization": f"Bearer {_OAUTH_TOKEN}"}
-
-    """
-    Generates headers for GitHub API requests using the current token.
-    """
-    decrypted_tokens = load_tokens()  # Load and decrypt tokens
-    if decrypted_tokens:
-        token = list(decrypted_tokens.values())[0]  # Use the first token
-        logging.debug(f"Using GitHub token: {token[:10]}****")
-        return {
-            'Authorization': f'token {token}',
-            'Accept': 'application/vnd.github+json',
-            'X-GitHub-Api-Version': '2022-11-28'
-        }
-    else:
-        logging.error("No GitHub tokens are available.")
-        return {}
+    return {
+        "Authorization": f"token {_OAUTH_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
 
     
 def get_repo_info(repo_name, headers):

--- a/GitSleuth_Groups.py
+++ b/GitSleuth_Groups.py
@@ -106,6 +106,11 @@ def create_search_queries(keywords, filter_placeholders=True):
             f"org:{keywords} \"sk_live_\"" if keywords else "sk_live_",
             f"repo:{keywords}/{keywords} \"ghp_\"" if keywords and '/' in keywords else "ghp_",
             f"shodan_api_key language:Python {domain_filter} {placeholders}",
+            f"VERCEL_API_TOKEN {domain_filter} {placeholders}",
+            f"HUGGINGFACEHUB_API_TOKEN {domain_filter} {placeholders}",
+            f"SUPABASE_SERVICE_ROLE_KEY {domain_filter} {placeholders}",
+            f"SENTRY_DSN {domain_filter} {placeholders}",
+            f"ROLLBAR_ACCESS_TOKEN {domain_filter} {placeholders}",
         ],
         "OAuth Credentials": [
             f"extension:json googleusercontent client_secret {domain_filter} {placeholders}",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
 - Export results to Excel or CSV
 - Sleek dark theme for the GUI
 - Keyword filter field in the GUI for quickly narrowing searches
+- Searches include modern API tokens like Vercel, Hugging Face, Supabase,
+  Sentry, and Rollbar
 
 - Optional session keep-alive after closing the GUI
 

--- a/SEARCH_QUERIES.md
+++ b/SEARCH_QUERIES.md
@@ -76,6 +76,11 @@ This document lists example search queries for locating secrets in public reposi
 | **Third-Party API Keys and Tokens** | `ghp_` | GitHub personal access tokens. |
 | **Third-Party API Keys and Tokens** | `TWILIO_AUTH_TOKEN` | Twilio API auth tokens. |
 | **Third-Party API Keys and Tokens** | `shodan_api_key language:Python` | Shodan API keys in Python projects. |
+| **Third-Party API Keys and Tokens** | `VERCEL_API_TOKEN` | Vercel deployment API tokens. |
+| **Third-Party API Keys and Tokens** | `HUGGINGFACEHUB_API_TOKEN` | Hugging Face API tokens. |
+| **Third-Party API Keys and Tokens** | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role keys. |
+| **Third-Party API Keys and Tokens** | `SENTRY_DSN` | Sentry DSN containing secrets. |
+| **Third-Party API Keys and Tokens** | `ROLLBAR_ACCESS_TOKEN` | Rollbar access tokens. |
 | **OAuth Credentials** | `extension:json googleusercontent client_secret` | Google OAuth client secrets in JSON. |
 | **OAuth Credentials** | `filename:client_secrets.json "client_secret"` | Typical Google OAuth client_secrets.json file. |
 | **OAuth Credentials** | `CLIENT_SECRET` | Files referencing a generic client secret. |

--- a/Token_Manager.py
+++ b/Token_Manager.py
@@ -1,11 +1,9 @@
 
 # Token_Manager.py
-import os
 import json
-from cryptography.fernet import Fernet
-import json
-import os
 import logging
+import os
+from cryptography.fernet import Fernet
 TOKEN_FILE = 'tokens.json'
 KEY_FILE = 'token_key.key'
 
@@ -53,27 +51,6 @@ def add_token(name: str, token: str) -> None:
     tokens[name] = token
     _save_tokens(tokens)    
 
-def load_tokens():
-    """Load saved GitHub tokens from TOKEN_FILE."""
-    if not os.path.exists(TOKEN_FILE):
-        return {}
-    try:
-        with open(TOKEN_FILE, 'r', encoding='utf-8') as f:
-            return json.load(f)
-    except Exception as exc:
-        logging.error(f"Failed to load tokens: {exc}")
-        return {}
-
-def _save_tokens(tokens):
-    with open(TOKEN_FILE, 'w', encoding='utf-8') as f:
-        json.dump(tokens, f)
-
-def add_token(name, token):
-    """Add a new token to the token store."""
-    tokens = load_tokens()
-    tokens[name] = token
-    _save_tokens(tokens)
-
 def delete_token(name):
     """Remove a token by name if it exists."""
 
@@ -82,24 +59,6 @@ def delete_token(name):
         del tokens[name]
         _save_tokens(tokens)
 
-
-def switch_token(config=None) -> bool:
-    """Rotate the active token stored in GITHUB_OAUTH_TOKEN."""
-    tokens = list(load_tokens().values())
-    if not tokens:
-        return False
-    current = os.environ.get('GITHUB_OAUTH_TOKEN')
-    if current not in tokens:
-        os.environ['GITHUB_OAUTH_TOKEN'] = tokens[0]
-        return True
-    if len(tokens) == 1:
-        return False
-    idx = tokens.index(current)
-    next_token = tokens[(idx + 1) % len(tokens)]
-    if next_token != current:
-        os.environ['GITHUB_OAUTH_TOKEN'] = next_token
-        return True
-    return False
 
 def switch_token(_config=None):
     """Rotate the GITHUB_OAUTH_TOKEN environment variable among saved tokens."""


### PR DESCRIPTION
## Summary
- expand the third-party API key lists
- include Vercel, Hugging Face, Supabase, Sentry and Rollbar tokens
- expose new queries to the query generator
- reduce merge conflicts by deduplicating token logic and generalizing `.gitignore`

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`
