### PR TITLE
Add entropy-based secret filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ known dummy secrets so matching snippets are ignored.
 Enable `USE_DETECT_SECRETS` to scan snippets with the `detect-secrets`
 tool and set `DETECT_SECRETS_BASELINE` to a baseline file for allowlisted
 secrets.
+Set `ENTROPY_THRESHOLD` (bits/char) to skip low-entropy values that
+look like placeholders.
 The application ships with a default GitHub OAuth client ID so it works out of
 the box. Set `GITHUB_OAUTH_CLIENT_ID` to override it and define
 `GITHUB_OAUTH_CLIENT_SECRET` if your OAuth app requires a secret.

--- a/config.json
+++ b/config.json
@@ -17,6 +17,7 @@
         "changeme"
     ],
     "USE_DETECT_SECRETS": false,
-    "DETECT_SECRETS_BASELINE": ""
+    "DETECT_SECRETS_BASELINE": "",
+    "ENTROPY_THRESHOLD": 3.5
 
 }


### PR DESCRIPTION
## Summary
- compute Shannon entropy for snippet assignments
- filter placeholder snippets when entropy is below configurable threshold
- document ENTROPY_THRESHOLD config option

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`