### PR TITLE
Implement path-based secret filtering

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -39,7 +39,7 @@ from GitSleuth_Groups import (
     get_query_description,
     PLACEHOLDERS,
 )
-from GitSleuth import extract_snippets, switch_token
+from GitSleuth import extract_snippets, switch_token, _path_is_ignored
 from GitSleuth_API import RateLimitException, get_headers, check_rate_limit
 from OAuth_Manager import oauth_login, fetch_username
 # Token management imports are kept for future use
@@ -607,6 +607,10 @@ class GitSleuthGUI(QMainWindow):
         self.status_bar.showMessage(f"Processing {repo_name}")
         QApplication.processEvents()
         file_path = item.get('path', '')
+        config = load_config()
+        patterns = config.get("IGNORED_PATH_PATTERNS", [])
+        if _path_is_ignored(file_path, patterns):
+            return
         file_contents = GitSleuth_API.get_file_contents(repo_name, file_path, headers)
         if file_contents:
             snippets = extract_snippets(

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ When starting OAuth authentication, your default browser will automatically open
 to the GitHub device flow page so you can enter the provided code.
 
 ## Configuration
-Edit `config.json` to adjust log level, ignored filenames, and whether
-placeholder terms are filtered from queries and results. When enabled the
+Edit `config.json` to adjust log level, ignored filenames, and path patterns
+that should be skipped (e.g. `tests/`, `examples/`, or files containing `.sample.`).
+You can also control whether placeholder terms are filtered from queries and results. When enabled the
 filter removes hits where environment variables have empty or placeholder
 values. You can also define `ALLOWLIST_PATTERNS` with regex strings for
 known dummy secrets so matching snippets are ignored.

--- a/config.json
+++ b/config.json
@@ -5,6 +5,11 @@
         "test.md",
         "sample.config"
     ],
+    "IGNORED_PATH_PATTERNS": [
+        "tests/",
+        "examples/",
+        ".sample."
+    ],
     "SESSION_KEEP_ALIVE_MINUTES": 0,
     "SAVED_USERNAME": "",
     "FILTER_PLACEHOLDERS": true,


### PR DESCRIPTION
## Summary
- add `IGNORED_PATH_PATTERNS` to configuration
- implement `_path_is_ignored` helper in `GitSleuth.py`
- skip files matching these patterns in CLI and GUI flows
- document new setting in README

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`
