### PR TITLE
Expand snippet and window sizes

### DIFF
--- a/GitSleuth.py
+++ b/GitSleuth.py
@@ -212,7 +212,7 @@ def get_domain_input():
     """
     return input("Enter your organization's domain for search (e.g., 'google.com'): ")
 
-def truncate_snippet(snippet, length=100):
+def truncate_snippet(snippet, length=200):
     """
     Truncates a snippet to a specified maximum length.
 
@@ -622,8 +622,9 @@ def extract_snippets(content, query, filter_placeholders=True, allowlist_pattern
     for term in query_terms:
         pattern = re.compile(re.escape(term), re.IGNORECASE)
         for match in pattern.finditer(content):
-            start = max(match.start() - 30, 0)
-            end = min(match.end() + 30, len(content))
+            # Grab a larger snippet around the search term for more context
+            start = max(match.start() - 60, 0)
+            end = min(match.end() + 60, len(content))
             snippet = content[start:end].replace('\n', ' ').strip()
             if snippet not in snippets and not _has_allowlist_comment(content, start, end):
                 snippets.append(snippet)

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -201,8 +201,8 @@ class GitSleuthGUI(QMainWindow):
         search_results_layout.addWidget(self.clear_results_button)
 
         # Geometry setup
-        # Expand the default window size for better spacing
-        self.setGeometry(200, 150, 1200, 750)
+        # Expand the default window size to accommodate larger snippets
+        self.setGeometry(200, 150, 1400, 850)
 
     def setupSearchInputArea(self, layout):
         """Build the search input widgets and action buttons."""
@@ -298,7 +298,8 @@ class GitSleuthGUI(QMainWindow):
         self.results_table.setColumnWidth(1, 220)
         self.results_table.setColumnWidth(2, 180)
         self.results_table.setColumnWidth(3, 250)
-        self.results_table.setColumnWidth(4, 300)
+        # Provide a wider column to display longer snippets
+        self.results_table.setColumnWidth(4, 450)
         # Stretch the snippets column to use remaining space
         self.results_table.horizontalHeader().setSectionResizeMode(
             4, QHeaderView.Stretch
@@ -723,7 +724,7 @@ class TokenManagementDialog(QDialog):
         super(TokenManagementDialog, self).__init__(parent)
         self.setWindowTitle('Token Management')
         # Provide more space for token information
-        self.setGeometry(100, 100, 500, 350)
+        self.setGeometry(100, 100, 600, 400)
         self.layout = QVBoxLayout(self)
 
         self.setupUI()


### PR DESCRIPTION
## Summary
- expand the snippet range returned when parsing content
- increase allowed snippet length
- widen the snippet column in the results table
- enlarge the main window and token management dialog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`