### PR TITLE
Update to scikit-learn naming

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -34,8 +34,8 @@ from PyQt5.QtCore import QUrl, Qt, QTimer
 from PyQt5.QtGui import QDesktopServices, QPalette, QColor
 
 import pandas as pd
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.linear_model import LogisticRegression
+from scikit-learn.feature_extraction.text import TfidfVectorizer
+from scikit-learn.linear_model import LogisticRegression
 import numpy as np
 from scipy.sparse import hstack, csr_matrix
 


### PR DESCRIPTION
## Summary
- swap out sklearn references for `scikit-learn`

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py` *(fails: invalid syntax)*