### PR TITLE
Replace sklearn with scikit-learn

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -35,8 +35,8 @@ from PyQt5.QtCore import QUrl, Qt, QTimer
 from PyQt5.QtGui import QDesktopServices, QPalette, QColor
 
 import pandas as pd
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.linear_model import LogisticRegression
+from scikit-learn.feature_extraction.text import TfidfVectorizer
+from scikit-learn.linear_model import LogisticRegression
 import numpy as np
 from scipy.sparse import hstack, csr_matrix
 


### PR DESCRIPTION
## Summary
- update imports to reference scikit-learn instead of sklearn

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py` *(fails: SyntaxError)*