### PR TITLE
Fix training error when only one label class

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -855,6 +855,12 @@ class GitSleuthGUI(QMainWindow):
             X = hstack([text_features, csr_matrix(extra)])
 
             y = df["Label"].apply(lambda x: 1 if x == "True Positive" else 0)
+            if y.nunique() < 2:
+                self.ml_output.append(
+                    "Training requires at least two label classes."
+                )
+                return
+
             model = LogisticRegression(max_iter=1000)
             model.fit(X, y)
             self.ml_output.append(f"Model trained on {len(df)} samples.")

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The labeled data is stored in `training_labels.csv`. Models are currently kept i
 Example passwords for experimentation are provided in `training_data.csv`.
 Training uses TF‑IDF text features combined with entropy and character composition metrics
 
+Ensure your labeled dataset includes both **True Positive** and **False Positive** examples,
+otherwise model training will fail with a single-class error.
+
 (length, numeric %, alphabetic %, special %) plus simple dictionary and pattern
 checks to help distinguish real secrets from placeholders. Additional features
 also encode the file type (config, source, log, other) and simple structural


### PR DESCRIPTION
## Summary
- prevent ML training when training_labels.csv has only one label class
- document need for at least two classes in README

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`
