### PR TITLE
Fix export labels button

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -529,12 +529,8 @@ class GitSleuthGUI(QMainWindow):
             self.status_bar.showMessage("Error exporting results.")
 
     def export_labels_to_csv(self):
-        """Export labeled results to a CSV file and save to training_labels.csv."""
-        filename, _ = QFileDialog.getSaveFileName(self, "Save Labeled Data", "", "CSV Files (*.csv)")
-        if filename:
-            self.write_labels_to_csv(filename)
-            # Also persist to training_labels.csv
-            self.write_labels_to_csv("training_labels.csv")
+        """Export labeled results directly to training_labels.csv."""
+        self.write_labels_to_csv("training_labels.csv")
 
     def write_labels_to_csv(self, filename):
         try:


### PR DESCRIPTION
## Summary
- skip the Save File dialog when exporting labels

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`
