### PR TITLE
Add search preset support

### DIFF
--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -30,6 +30,7 @@ from PyQt5.QtWidgets import (
     QSpinBox,
     QDialogButtonBox,
     QHeaderView,
+    QInputDialog,
 )
 from PyQt5.QtCore import QUrl, Qt, QTimer
 from PyQt5.QtGui import QDesktopServices, QPalette, QColor
@@ -191,6 +192,7 @@ class GitSleuthGUI(QMainWindow):
         self.search_active = False
         self.session_keep_alive = config.get("SESSION_KEEP_ALIVE_MINUTES", 0)
         self.filter_placeholders = config.get("FILTER_PLACEHOLDERS", True)
+        self.presets = config.get("SEARCH_PRESETS", {})
         self.exit_timer: Optional[QTimer] = None
         self.initUI()
         self.restore_oauth_session()
@@ -308,6 +310,22 @@ class GitSleuthGUI(QMainWindow):
             "General Configuration & Credential Files",
             "Search All",
         ])
+
+        self.preset_dropdown = QComboBox(self)
+        self.preset_dropdown.addItem("None")
+        self.preset_dropdown.activated.connect(self.apply_selected_preset)
+        layout.addWidget(self.preset_dropdown)
+        self.update_preset_dropdown()
+
+        self.save_preset_btn = QPushButton("Save Preset", self)
+        self.save_preset_btn.setFixedWidth(110)
+        self.save_preset_btn.clicked.connect(self.save_current_preset)
+        layout.addWidget(self.save_preset_btn)
+
+        self.delete_preset_btn = QPushButton("Delete", self)
+        self.delete_preset_btn.setFixedWidth(80)
+        self.delete_preset_btn.clicked.connect(self.delete_current_preset)
+        layout.addWidget(self.delete_preset_btn)
 
         self.search_button = QPushButton("Search", self)
         # Slightly wider buttons for clarity
@@ -454,6 +472,48 @@ class GitSleuthGUI(QMainWindow):
                 config["SAVED_USERNAME"] = ""
                 save_config(config)
         return False
+
+    def update_preset_dropdown(self) -> None:
+        """Populate the preset dropdown from stored presets."""
+        self.preset_dropdown.blockSignals(True)
+        self.preset_dropdown.clear()
+        self.preset_dropdown.addItem("None")
+        for name in sorted(self.presets.keys()):
+            self.preset_dropdown.addItem(name)
+        self.preset_dropdown.blockSignals(False)
+
+    def save_current_preset(self) -> None:
+        """Save the current keywords and search group as a preset."""
+        name, ok = QInputDialog.getText(self, "Save Preset", "Preset name:")
+        if ok and name:
+            self.presets[name] = {
+                "keywords": self.keyword_input.text().strip(),
+                "group": self.search_group_dropdown.currentText(),
+            }
+            config["SEARCH_PRESETS"] = self.presets
+            save_config(config)
+            self.update_preset_dropdown()
+            self.preset_dropdown.setCurrentText(name)
+
+    def delete_current_preset(self) -> None:
+        """Delete the currently selected preset."""
+        name = self.preset_dropdown.currentText()
+        if name and name != "None" and name in self.presets:
+            del self.presets[name]
+            config["SEARCH_PRESETS"] = self.presets
+            save_config(config)
+            self.update_preset_dropdown()
+
+    def apply_selected_preset(self) -> None:
+        """Fill input fields from the selected preset."""
+        name = self.preset_dropdown.currentText()
+        if name and name in self.presets:
+            data = self.presets[name]
+            self.keyword_input.setText(data.get("keywords", ""))
+            group = data.get("group", "")
+            idx = self.search_group_dropdown.findText(group)
+            if idx >= 0:
+                self.search_group_dropdown.setCurrentIndex(idx)
 
     
     def clear_results(self):

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
 - OAuth device flow authentication with secure token storage and rotation
 - Optional session keep-alive after closing the GUI with automatic login restoration
 - Dark-themed GUI and CLI with a keyword filter to narrow searches
+- User-defined search presets for quick access to common search groups
 - Searches include tokens for Vercel, Hugging Face, Supabase, Sentry, Rollbar, GitLab, Cloudflare, Vault and Pinecone
 - Status bar shows rate limit pauses and tokens rotate automatically
 - Export results to Excel or CSV
@@ -48,6 +49,9 @@ GitSleuth searches GitHub repositories for sensitive data. It provides both a co
 python GitSleuth_GUI.py
 ```
 Use the **Keywords** field to limit searches to specific domains or terms.
+
+Use **Save Preset** to store the current keywords and group selection.
+Choose a preset from the dropdown to quickly re-run saved searches.
 
 Each result row also displays the description of the rule that matched.
 

--- a/config.json
+++ b/config.json
@@ -23,6 +23,7 @@
     ],
     "USE_DETECT_SECRETS": false,
     "DETECT_SECRETS_BASELINE": "",
-    "ENTROPY_THRESHOLD": 3.5
+    "ENTROPY_THRESHOLD": 3.5,
+    "SEARCH_PRESETS": {}
 
 }


### PR DESCRIPTION
## Summary
- support saving custom search presets in the GUI
- document search presets in README
- store presets in config

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`