### PR TITLE
Add red highlight for secrets in GUI results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project are documented in this file.
 - Updated `AGENTS.md` to require changelog updates for every change
 - Case-insensitive highlighting of search terms in snippets
 - Enabled color highlighting of secrets by initializing colorama
+- GUI results table now highlights matched terms in red
 
 - Fixed invisible tooltips for toolbar actions and differentiated clear icons
 - Dedicated toolbar with icons for clearing log/results and exporting


### PR DESCRIPTION
## Summary
- highlight search terms in snippet results with `highlight_terms_html`
- use QLabel for snippet cells so secrets appear in red
- document GUI snippet highlighting in changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`