### PR TITLE
Expand GUI snippet display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Optional integration with Yelp's `detect-secrets` for improved secret detection
 - Added detection utilities for environment variable names and token strings
 - Expanded snippet and window sizes for better context
+- Default window expanded further with word-wrapped snippets and automatic row resizing
 - Adjusted snippet context to 40 characters before and 100 after search terms
 - Added machine learning training interface with label export
 - High entropy search with entropy scores displayed in results

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -324,7 +324,7 @@ class GitSleuthGUI(QMainWindow):
 
         # Geometry setup
         # Expand the default window size to accommodate larger snippets
-        self.setGeometry(200, 150, 1400, 850)
+        self.setGeometry(200, 150, 1600, 900)
 
     def setupSearchInputArea(self, layout):
         """Build the search input widgets and action buttons."""
@@ -458,6 +458,10 @@ class GitSleuthGUI(QMainWindow):
         # Stretch the snippets column to use remaining space
         self.results_table.horizontalHeader().setSectionResizeMode(
             4, QHeaderView.Stretch
+        )
+
+        self.results_table.verticalHeader().setSectionResizeMode(
+            QHeaderView.ResizeToContents
         )
 
 
@@ -924,8 +928,10 @@ class GitSleuthGUI(QMainWindow):
             snippet_label = QLabel()
             snippet_label.setTextFormat(Qt.RichText)
             snippet_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+            snippet_label.setWordWrap(True)
             snippet_label.setText(highlighted)
             self.results_table.setCellWidget(row_position, 4, snippet_label)
+            self.results_table.resizeRowToContents(row_position)
 
             # Entropy column
             if score is None:


### PR DESCRIPTION
## Summary
- enlarge default GUI window size
- automatically resize table rows to fit long snippets
- enable word wrap for snippet cell labels

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`