### PR TITLE
Fix training crash with non-string snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project are documented in this file.
 - Graceful handling of token decryption errors
 - Fixed training error when only one label class
 - Fixed training failure when file paths contain non-string values
+- Fixed ML training crash when snippets contain non-string values
 - Updated `AGENTS.md` to require changelog updates for every change
 - Case-insensitive highlighting of search terms in snippets
 - Placeholder filtering checks assigned values for key reuse and bold markup

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -1017,6 +1017,8 @@ class GitSleuthGUI(QMainWindow):
             if df.empty:
                 self.ml_output.append("No labeled data to train on.")
                 return
+            # Ensure snippets are strings to avoid vectorizer errors
+            df["Snippet"] = df["Snippet"].astype(str).fillna("")
             vectorizer = TfidfVectorizer()
             text_features = vectorizer.fit_transform(df["Snippet"])
             paths = df.get("File Path", ["" for _ in range(len(df))])


### PR DESCRIPTION
## Summary
- sanitize Snippet column in GUI ML training
- document fix in `CHANGELOG`

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`