### PR TITLE
Add high entropy filter toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 - Documented release date for prior changes in this file
+- Results label defaults to "False Positive" for LOW entropy or scores ≤ 3.5
+- Added "Show High Entropy Only" checkbox to hide low-entropy results and disable ML features
 
 ## 2025-05-29
 ### Added

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QCheckBox,
     QVBoxLayout,
     QHBoxLayout,
     QComboBox,
@@ -65,6 +66,7 @@ from OAuth_Manager import oauth_login, fetch_username
 from Token_Manager import load_tokens, add_token, delete_token
 
 CONFIG_FILE = 'config.json'
+HIGH_ENTROPY_THRESHOLD = 4.0
 
 
 def apply_dark_palette(app):
@@ -298,6 +300,13 @@ class GitSleuthGUI(QMainWindow):
         self.export_labels_action.setEnabled(False)
         toolbar.addAction(self.export_labels_action)
 
+        self.high_entropy_checkbox = QCheckBox("Show High Entropy Only", self)
+        self.high_entropy_checkbox.setToolTip(
+            "Hide low entropy results and disable ML features"
+        )
+        self.high_entropy_checkbox.stateChanged.connect(self.apply_entropy_filter)
+        toolbar.addWidget(self.high_entropy_checkbox)
+
         # Add search input widgets to the toolbar
         self.setupSearchInputArea(toolbar)
 
@@ -307,15 +316,15 @@ class GitSleuthGUI(QMainWindow):
         main_layout = QVBoxLayout(main_widget)
 
         # Tab widget setup
-        tab_widget = QTabWidget(self)
+        self.tab_widget = QTabWidget(self)
         search_results_tab = QWidget()
         ml_tab = QWidget()
         log_tab = QWidget()
-        tab_widget.addTab(search_results_tab, "Search Results")
-        tab_widget.addTab(ml_tab, "ML")
-        tab_widget.addTab(log_tab, "Log")
+        self.tab_widget.addTab(search_results_tab, "Search Results")
+        self.ml_tab_index = self.tab_widget.addTab(ml_tab, "ML")
+        self.tab_widget.addTab(log_tab, "Log")
 
-        main_layout.addWidget(tab_widget)
+        main_layout.addWidget(self.tab_widget)
 
         # Setup for the search results tab
         search_results_layout = QVBoxLayout(search_results_tab)
@@ -572,6 +581,21 @@ class GitSleuthGUI(QMainWindow):
         self.status_bar.showMessage("Search stopped.")
         self.check_enable_export()
         QApplication.processEvents()  # Ensure UI updates after stopping
+
+    def apply_entropy_filter(self):
+        """Hide low entropy rows and toggle ML features."""
+        checked = self.high_entropy_checkbox.isChecked()
+        self.train_button.setEnabled(not checked)
+        self.tab_widget.setTabEnabled(self.ml_tab_index, not checked)
+        for row in range(self.results_table.rowCount()):
+            entropy_item = self.results_table.item(row, 5)
+            text = entropy_item.text() if entropy_item else ""
+            try:
+                score = float(text)
+            except ValueError:
+                score = None
+            hide = checked and (score is None or score < HIGH_ENTROPY_THRESHOLD)
+            self.results_table.setRowHidden(row, hide)
     def export_results_to_csv(self):
         """
         Exports the search results displayed in the table to a CSV file.
@@ -896,6 +920,10 @@ class GitSleuthGUI(QMainWindow):
         for snippet, score in zip(snippets, scores):
             if not self.search_active:
                 break
+            if self.high_entropy_checkbox.isChecked() and (
+                score is None or score < HIGH_ENTROPY_THRESHOLD
+            ):
+                continue
             row_position = self.results_table.rowCount()
             self.results_table.insertRow(row_position)
 
@@ -940,7 +968,7 @@ class GitSleuthGUI(QMainWindow):
                 "Classify the result as a true or false positive"
             )
             label_box.addItems(["", "True Positive", "False Positive"])
-            if score is None:
+            if score is None or score <= 3.5:
                 label_box.setCurrentText("False Positive")
             elif score > 3.5:
                 label_box.setCurrentText("True Positive")


### PR DESCRIPTION
## Summary
- add HIGH_ENTROPY_THRESHOLD constant and checkbox on the toolbar
- skip low-entropy rows when filtering is active
- disable ML tab and button while showing high-entropy only
- document high entropy filter in changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`