### PR TITLE
Restore high entropy filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 - Documented release date for prior changes in this file
+- Results label defaults to "False Positive" for LOW entropy or scores ≤ 3.5
+- "Show High Entropy Only" filter hides low-entropy rows and disables ML tab
 
 ## 2025-05-29
 ### Added


### PR DESCRIPTION
## Summary
- hide low entropy results with "Show High Entropy Only" checkbox
- disable ML features when high entropy filter is active
- document the option in the changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`