### PR TITLE
Fix button label text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 - Documented release date for prior changes in this file
 - Results label defaults to "False Positive" for LOW entropy or scores ≤ 3.5
 - Added "Show High Entropy Only" checkbox to hide low-entropy results and disable ML features
+- Button label changed from "Show High Entropy Only" to "Hide Low Entropy Results"
 - Cleaned AGENTS.md to remove merge conflict markers and clarify instructions
 - Introduced `auto_pull.sh` wrapper to run `git pull` with automatic conflict
   resolution and updated AGENTS.md accordingly

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -302,7 +302,7 @@ class GitSleuthGUI(QMainWindow):
         self.export_labels_action.setEnabled(False)
         toolbar.addAction(self.export_labels_action)
 
-        self.high_entropy_checkbox = QCheckBox("Show High Entropy Only", self)
+        self.high_entropy_checkbox = QCheckBox("Hide Low Entropy Results", self)
         self.high_entropy_checkbox.setToolTip(
 
             "Hide results with entropy scores at or below the threshold"
@@ -453,7 +453,7 @@ class GitSleuthGUI(QMainWindow):
         self.quit_button.clicked.connect(self.force_quit)
         add(self.quit_button)
 
-        self.high_entropy_checkbox = QCheckBox("Show High Entropy Only", self)
+        self.high_entropy_checkbox = QCheckBox("Hide Low Entropy Results", self)
         self.high_entropy_checkbox.setToolTip(
             "Hide results with entropy 3.5 or lower and disable ML features"
         )


### PR DESCRIPTION
## Summary
- rename "Show High Entropy Only" button to "Hide Low Entropy Results"
- document the renamed button in the changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`