### PR TITLE
Fix secret highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
 - Console table output centered for improved readability
 
 - GUI results table centered for improved readability
+- GUI secrets now display the secret text in red and preceding search terms in blue
 
 
 
@@ -52,7 +53,7 @@ All notable changes to this project are documented in this file.
 - GUI results table now highlights matched terms in red
 - Entropy scores computed for assigned values with placeholder filtering
 - Entropy detection now matches query terms within variable names, preventing "N/A" scores
-- Extracts secret values after common keywords with blue highlighting and entropy displayed as 'LOW' when unknown
+- Extracts secret values after common keywords with red highlighting and entropy displayed as 'LOW' when unknown
 
 ### Fixed
 - Fixed invisible tooltips for toolbar actions and differentiated clear icons

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -180,11 +180,11 @@ def compute_features(text: str, file_path: str = "") -> list[float]:
 
 
 def highlight_terms_html(text: str, query: str) -> str:
-    """Return HTML text with search terms highlighted in red and secrets in blue."""
+    """Return HTML text with search terms highlighted in blue and secrets in red."""
     # Highlight secrets first
     def _highlight_secret(match: re.Match) -> str:
         secret = match.group(1)
-        highlighted = f'<b><span style="color:blue">{secret}</span></b>'
+        highlighted = f'<b><span style="color:red">{secret}</span></b>'
         return match.group(0).replace(secret, highlighted)
 
     secret_pattern = re.compile(
@@ -198,7 +198,7 @@ def highlight_terms_html(text: str, query: str) -> str:
     for term in terms:
         pattern = re.compile(re.escape(term), re.IGNORECASE)
         text = pattern.sub(
-            lambda m: f'<span style="color:red">{m.group(0)}</span>',
+            lambda m: f'<span style="color:blue">{m.group(0)}</span>',
             text,
         )
     return text


### PR DESCRIPTION
## Summary
- swap color-coding so secrets are red and the preceding text is blue
- document new GUI color behavior in `CHANGELOG.md`

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`