### PR TITLE
Fix ML tester fallback when libs missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project are documented in this file.
 - Added `ML_Tester.py` to train on `training_data.csv`, report accuracy, and
   analyze user-provided phrases for secrets
 
+- `ML_Tester.py` now falls back to a built-in logistic regression when
+  pandas or scikit-learn are unavailable.
+
 - Added "Train Example Model" and "Analyze Phrase" features in the ML tab for
   accuracy testing and secret detection
 

--- a/ML_Tester.py
+++ b/ML_Tester.py
@@ -1,9 +1,84 @@
+"""Utility for testing whether a phrase resembles a real password."""
+
 import re
-import pandas as pd
-from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score
+from typing import Any
+
+# Optional third-party imports
+try:
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - pandas optional
+    pd = None  # type: ignore
+
+try:
+    from sklearn.linear_model import LogisticRegression  # type: ignore
+    from sklearn.model_selection import train_test_split  # type: ignore
+    from sklearn.metrics import accuracy_score  # type: ignore
+except Exception:  # pragma: no cover - scikit-learn optional
+    LogisticRegression = None  # type: ignore
+    train_test_split = None  # type: ignore
+    accuracy_score = None  # type: ignore
+
+import csv
+import math
+import random
 from GitSleuth import _shannon_entropy, PRECEDING_KEYWORDS
+
+
+class SimpleLogisticRegression:
+    """Very small fallback implementation of logistic regression."""
+
+    def __init__(self, lr: float = 0.1, n_iter: int = 500) -> None:
+        self.lr = lr
+        self.n_iter = n_iter
+        self.weights: list[float] | None = None
+        self.bias: float = 0.0
+
+    def fit(self, X: list[list[float]], y: list[int]) -> None:
+        if not X:
+            raise ValueError("Empty training data")
+        n_features = len(X[0])
+        self.weights = [0.0] * n_features
+        self.bias = 0.0
+        for _ in range(self.n_iter):
+            for features, label in zip(X, y):
+                z = self.bias + sum(w * f for w, f in zip(self.weights, features))
+                pred = 1.0 / (1.0 + math.exp(-z))
+                error = label - pred
+                for i in range(n_features):
+                    self.weights[i] += self.lr * error * features[i]
+                self.bias += self.lr * error
+
+    def predict(self, rows: list[list[float]]) -> list[int]:
+        if self.weights is None:
+            raise RuntimeError("Model is not trained")
+        preds: list[int] = []
+        for features in rows:
+            z = self.bias + sum(w * f for w, f in zip(self.weights, features))
+            prob = 1.0 / (1.0 + math.exp(-z))
+            preds.append(1 if prob >= 0.5 else 0)
+        return preds
+
+
+def _split_data(X: list[list[float]], y: list[int], test_size: float = 0.2, random_state: int = 42) -> tuple[list[list[float]], list[list[float]], list[int], list[int]]:
+    """Simple replacement for ``train_test_split``."""
+    rng = random.Random(random_state)
+    indices = list(range(len(X)))
+    rng.shuffle(indices)
+    split = int(len(indices) * (1 - test_size))
+    train_idx, test_idx = indices[:split], indices[split:]
+    X_train = [X[i] for i in train_idx]
+    X_test = [X[i] for i in test_idx]
+    y_train = [y[i] for i in train_idx]
+    y_test = [y[i] for i in test_idx]
+    return X_train, X_test, y_train, y_test
+
+
+def _accuracy_score(y_true: list[int], y_pred: list[int]) -> float:
+    """Return fraction of correct predictions."""
+    if not y_true:
+        return 0.0
+    correct = sum(1 for a, b in zip(y_true, y_pred) if a == b)
+    return correct / len(y_true)
 
 
 def _compute_features(text: str) -> list[float]:
@@ -22,30 +97,57 @@ def _compute_features(text: str) -> list[float]:
 
 def load_training() -> tuple[list[list[float]], list[int]]:
     """Load passwords and placeholders from ``training_data.csv``."""
-    df = pd.read_csv("training_data.csv")
     X: list[list[float]] = []
     y: list[int] = []
-    for pwd in df.get("RealPassword", []):
+    if pd is not None:
+        df = pd.read_csv("training_data.csv")
+        real_pwds = df.get("RealPassword", [])
+        placeholders = df.get("Placeholder", [])
+    else:  # Fallback to csv module
+        with open("training_data.csv", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            real_pwds = []
+            placeholders = []
+            for row in reader:
+                real_pwds.append(row.get("RealPassword", ""))
+                placeholders.append(row.get("Placeholder", ""))
+
+    for pwd in real_pwds:
         if isinstance(pwd, str) and pwd:
             X.append(_compute_features(pwd))
             y.append(1)
-    for pwd in df.get("Placeholder", []):
+    for pwd in placeholders:
         if isinstance(pwd, str) and pwd:
             X.append(_compute_features(pwd))
             y.append(0)
+
     return X, y
 
 
-def train_model() -> LogisticRegression:
+def train_model():
     """Train a logistic regression model and print test accuracy."""
     X, y = load_training()
     if not X:
         raise RuntimeError("No training data available")
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-    model = LogisticRegression(max_iter=1000)
-    model.fit(X_train, y_train)
-    preds = model.predict(X_test)
-    acc = accuracy_score(y_test, preds)
+
+    if train_test_split is not None:
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=42
+        )
+    else:
+        X_train, X_test, y_train, y_test = _split_data(X, y, test_size=0.2)
+
+    if LogisticRegression is not None:
+        model: Any = LogisticRegression(max_iter=1000)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+        acc = accuracy_score(y_test, preds) if accuracy_score else _accuracy_score(y_test, preds)
+    else:
+        model = SimpleLogisticRegression()
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+        acc = _accuracy_score(y_test, preds)
+
     print(f"Model accuracy: {acc * 100:.2f}% on held-out data")
     return model
 
@@ -56,7 +158,7 @@ SECRET_RE = re.compile(
 )
 
 
-def analyze_phrase(model: LogisticRegression, phrase: str) -> None:
+def analyze_phrase(model: Any, phrase: str) -> None:
     """Analyze *phrase* for secrets using the trained model."""
     matches = list(SECRET_RE.finditer(phrase))
 


### PR DESCRIPTION
## Summary
- implement graceful fallback when pandas or scikit-learn aren't available
- add a simple logistic regression and custom train/test split
- document the fallback behaviour

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`

------
https://chatgpt.com/codex/tasks/task_e_683f38d9204083229657626ec73bd88f