### PR TITLE
Remove Train Example Model button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project are documented in this file.
   accuracy testing and secret detection
 - Added "Test Example Model" button to evaluate the sample classifier on
   `testing_data.csv` directly from the GUI
+- Removed "Train Example Model" button; testing and phrase analysis now
+  train the sample classifier automatically
 
 
 

--- a/GitSleuth_GUI.py
+++ b/GitSleuth_GUI.py
@@ -400,13 +400,6 @@ class GitSleuthGUI(QMainWindow):
         self.train_button.clicked.connect(self.train_model)
         ml_tab_layout.addWidget(self.train_button)
 
-        self.sample_train_button = QPushButton("Train Example Model", self)
-        self.sample_train_button.setToolTip(
-            "Train simple classifier on training_data.csv"
-        )
-        self.sample_train_button.clicked.connect(self.train_sample_model)
-        ml_tab_layout.addWidget(self.sample_train_button)
-
         self.sample_test_button = QPushButton("Test Example Model", self)
         self.sample_test_button.setToolTip(
             "Evaluate sample classifier on testing_data.csv"

--- a/README.md
+++ b/README.md
@@ -73,12 +73,10 @@ context such as assignments or secret-setting function calls.
 
 #### Testing the Model
 
-Open the **ML** tab and click **Train Example Model** to build a simple
-classifier from `training_data.csv`. The tab shows the model's accuracy.
-Click **Test Example Model** to evaluate this classifier on
-`testing_data.csv` and display the accuracy in the output area.
-Enter any phrase in the provided field and click **Analyze Phrase** to
-highlight detected secrets, the preceding indicator, entropy score and
+Open the **ML** tab and click **Test Example Model** to evaluate a simple
+classifier on `testing_data.csv` and display the accuracy in the output
+area. Enter any phrase in the provided field and click **Analyze Phrase**
+to highlight detected secrets, the preceding indicator, entropy score and
 
 
 #### ML Workflow


### PR DESCRIPTION
## Summary
- drop GUI button that manually trained the sample model
- clarify README instructions to skip the training step
- note the removal in the changelog

## Testing
- `python -m py_compile GitSleuth_GUI.py OAuth_Manager.py Token_Manager.py GitSleuth.py GitSleuth_API.py`

------
https://chatgpt.com/codex/tasks/task_e_683f48b9bb888322953485b60c9c8649